### PR TITLE
Implement an efficient Int.prototype.eq0

### DIFF
--- a/int.js
+++ b/int.js
@@ -428,6 +428,10 @@ Int.prototype.eq = function (num) {
     return this.cmp(num) === 0;
 };
 
+Int.prototype.eq0 = function () {
+    return this._d.length === 0;
+};
+
 Int.prototype.ne = function (num) {
     return this.cmp(num) !== 0;
 };


### PR DESCRIPTION
It is between 50 and 100 times faster that .eq(0), and quite often needed (just a guess).
I realize I didn't write tests. Sorry about that but I don't have much time to do more.
